### PR TITLE
设置面板和其他位置的 UI 细节调整和文字更改

### DIFF
--- a/HashCalculator/HashCalculator.csproj
+++ b/HashCalculator/HashCalculator.csproj
@@ -147,6 +147,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Resources\DescTextBlockStyles.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/HashCalculator/Resources/DescTextBlockStyles.xaml
+++ b/HashCalculator/Resources/DescTextBlockStyles.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="DescTextBlockStyle" TargetType="{x:Type TextBlock}">
+        <Setter Property="TextWrapping" Value="NoWrap" />
+        <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        <Setter Property="Foreground" Value="#969696" />
+    </Style>
+</ResourceDictionary>

--- a/HashCalculator/ViewModels/SettingsViewModel.cs
+++ b/HashCalculator/ViewModels/SettingsViewModel.cs
@@ -14,8 +14,8 @@ namespace HashCalculator
         private double mainWndTop = double.NaN;
         private double mainWndLeft = double.NaN;
         private WindowState mainWindowState = WindowState.Normal;
-        private double settingsWndWidth = 530.0;
-        private double settingsWndHeight = 450.0;
+        private double settingsWndWidth = 600.0;
+        private double settingsWndHeight = 500.0;
         private AlgoType selectedAlgorithm = AlgoType.SHA1;
         private OutputType selectedOutputType = OutputType.BinaryUpper;
         private ExportType resultFileTypeExportAs = ExportType.TxtFile;

--- a/HashCalculator/Views/MainWindow.xaml
+++ b/HashCalculator/Views/MainWindow.xaml
@@ -132,7 +132,7 @@
                     Command="{Binding ExportHashResultCmd}"
                     IsEnabled="{Binding State, Converter={StaticResource ButtonEnabledCvt}}"
                     Style="{StaticResource ImageButtonStyle2}"
-                    ToolTip="导出哈希值：将表格中所有文件的哈希计算结果导出为文本文件&#10;导出的内容使用的输出方式受到 [默认输出方式] 的控制而不受各文件自己的 [输出方式] 的控制&#10;没有计算结果的行不会被导出，[导出] 列没有勾选的行也不会被导出">
+                    ToolTip="导出哈希值：将表格中所有文件的哈希计算结果导出为文件&#10;导出的内容使用的输出方式受到 [默认输出方式] 的控制而不受各文件自己的 [输出方式] 的控制&#10;没有计算结果的行不会被导出，[导出] 列没有勾选的行也不会被导出">
                     <Image Source="{Binding IsEnabled, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}, AncestorLevel=1}, Converter={StaticResource BtnExportEnabledImgCvt}}" />
                 </Button>
                 <Button
@@ -454,7 +454,7 @@
                 <DataGridTextColumn
                     MinWidth="80"
                     Binding="{Binding DurationofTask, StringFormat=f2}"
-                    Header="运行时长(秒)"
+                    Header="运行时长 (秒)"
                     Visibility="{Binding Source={x:Static local:Settings.Current}, Path=NoDurationColumn, Converter={StaticResource NoColumnCvt}, Mode=OneWay}" />
                 <DataGridTemplateColumn
                     CanUserSort="True"

--- a/HashCalculator/Views/SettingsPanel.xaml
+++ b/HashCalculator/Views/SettingsPanel.xaml
@@ -21,243 +21,243 @@
                 <ResourceDictionary Source="/Resources/ConverterResource.xaml" />
                 <ResourceDictionary Source="/Resources/TabControlItemStyles.xaml" />
                 <ResourceDictionary Source="/Resources/TabControlStyles.xaml" />
+                <ResourceDictionary Source="/Resources/DescTextBlockStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>
     <TabControl
         Margin="8"
-        ScrollViewer.HorizontalScrollBarVisibility="Auto"
-        ScrollViewer.VerticalScrollBarVisibility="Auto"
         Style="{DynamicResource TabControlStyle1}"
         TabStripPlacement="Left">
         <TabItem
             Padding="8"
             Header="常规设置"
             Style="{StaticResource TabItemStyle1}">
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-                <Grid Margin="4">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    <StackPanel
-                        Grid.Row="0"
-                        Margin="0,0,0,4"
-                        Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Text="同时计算多少个文件的哈希值：" />
-                        <ComboBox
-                            Grid.Column="2"
-                            DisplayMemberPath="Display"
-                            ItemsSource="{Binding AvailableTaskNumLimits}"
-                            SelectedValue="{Binding SelectedTaskNumberLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            SelectedValuePath="ItemValue" />
-                    </StackPanel>
-                    <StackPanel
-                        Grid.Row="1"
-                        Margin="0,0,0,4"
-                        Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Text="当选择的计算对象中包含文件夹时：" />
-                        <ComboBox
-                            Grid.Column="1"
-                            DisplayMemberPath="Display"
-                            ItemsSource="{Binding AvailableDroppedSearchPolicies}"
-                            SelectedValue="{Binding SelectedSearchPolicy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            SelectedValuePath="ItemValue" />
-                    </StackPanel>
-                    <StackPanel
-                        Grid.Row="2"
-                        Margin="0,0,0,4"
-                        Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Text="直接使用校验依据进行校验时：" />
-                        <ComboBox
-                            Grid.Column="1"
-                            DisplayMemberPath="Display"
-                            ItemsSource="{Binding AvailableQVSearchPolicies}"
-                            SelectedValue="{Binding SelectedQVSPolicy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            SelectedValuePath="ItemValue"
-                            ToolTip="当表格为空时，如果校验依据选择的是通用格式的哈希值文本文件，则：&#10;点击 [校验] 后程序会自动解析文件并在相同目录下寻找要计算哈希值的文件完成计算并显示校验结果。&#10;通用格式的哈希值文件请参考程序 [导出结果] 功能导出的文件的内容排布格式。" />
-                    </StackPanel>
-                    <CheckBox
-                        Grid.Row="3"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="在校验结果的色块中显示文字描述"
-                        IsChecked="{Binding ShowResultText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <CheckBox
-                        Grid.Row="4"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="右键选择删除文件时永久删除而不是移动到回收站"
-                        IsChecked="{Binding PermanentlyDeleteFiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <CheckBox
-                        Grid.Row="5"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="不显示“导出”列"
-                        IsChecked="{Binding NoExportColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <CheckBox
-                        Grid.Row="6"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="不显示“运行时长”列"
-                        IsChecked="{Binding NoDurationColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <CheckBox
-                        Grid.Row="7"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="不显示“文件大小”列"
-                        IsChecked="{Binding NoFileSizeColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <CheckBox
-                        Grid.Row="8"
-                        Margin="0,0,0,4"
-                        Padding="4,0,0,0"
-                        Content="允许打开多个窗口 (包括从系统右键菜单和关联文件启动)"
-                        IsChecked="{Binding RunInMultiInstMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </Grid>
-            </ScrollViewer>
+            <Grid Margin="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <StackPanel
+                    Grid.Row="0"
+                    Margin="0,0,0,4"
+                    Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Text="同时计算多少个文件的哈希值：" />
+                    <ComboBox
+                        Grid.Column="2"
+                        DisplayMemberPath="Display"
+                        ItemsSource="{Binding AvailableTaskNumLimits}"
+                        SelectedValue="{Binding SelectedTaskNumberLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        SelectedValuePath="ItemValue" />
+                </StackPanel>
+                <StackPanel
+                    Grid.Row="1"
+                    Margin="0,0,0,4"
+                    Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Text="当选择的计算对象中包含文件夹时：" />
+                    <ComboBox
+                        Grid.Column="1"
+                        DisplayMemberPath="Display"
+                        ItemsSource="{Binding AvailableDroppedSearchPolicies}"
+                        SelectedValue="{Binding SelectedSearchPolicy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        SelectedValuePath="ItemValue" />
+                </StackPanel>
+                <StackPanel
+                    Grid.Row="2"
+                    Margin="0,0,0,4"
+                    Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Text="直接使用校验依据进行校验时：" />
+                    <ComboBox
+                        Grid.Column="1"
+                        DisplayMemberPath="Display"
+                        ItemsSource="{Binding AvailableQVSearchPolicies}"
+                        SelectedValue="{Binding SelectedQVSPolicy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        SelectedValuePath="ItemValue"
+                        ToolTip="当表格为空时，如果校验依据选择的是通用格式的哈希值文本文件，则：&#10;点击 [校验] 后程序会自动解析文件并在相同目录下寻找要计算哈希值的文件完成计算并显示校验结果。&#10;通用格式的哈希值文件请参考程序 [导出结果] 功能导出的文件的内容排布格式。" />
+                </StackPanel>
+                <CheckBox
+                    Grid.Row="3"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="在校验结果的色块中显示文字描述"
+                    IsChecked="{Binding ShowResultText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox
+                    Grid.Row="4"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="右键选择删除文件时永久删除而不是移动到回收站"
+                    IsChecked="{Binding PermanentlyDeleteFiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox
+                    Grid.Row="5"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="不显示“导出”列"
+                    IsChecked="{Binding NoExportColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox
+                    Grid.Row="6"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="不显示“运行时长”列"
+                    IsChecked="{Binding NoDurationColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox
+                    Grid.Row="7"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="不显示“文件大小”列"
+                    IsChecked="{Binding NoFileSizeColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox
+                    Grid.Row="8"
+                    Margin="0,0,0,4"
+                    Padding="4,0,0,0"
+                    Content="允许打开多个窗口 (包括从系统右键菜单和关联文件启动)"
+                    IsChecked="{Binding RunInMultiInstMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </Grid>
         </TabItem>
         <TabItem
             Padding="8"
             Header="快捷菜单与文件关联"
             Style="{StaticResource TabItemStyle1}">
-            <ScrollViewer
+            <GroupBox
                 Margin="4"
-                HorizontalScrollBarVisibility="Auto"
-                VerticalScrollBarVisibility="Auto">
-                <GroupBox
-                    Padding="4,8,4,4"
-                    Foreground="Gray"
-                    Header="扩展系统右键菜单和关联 .hcb 文件">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <Button
-                            Grid.Row="0"
-                            Grid.Column="0"
-                            Margin="0,0,8,0"
-                            Padding="8"
-                            Background="{x:Null}"
-                            Command="{Binding InstallShellExtCmd}"
-                            Content="安装右键菜单并关联文件(用户)"
-                            IsEnabled="{Binding NotSettingShellExtension}" />
-                        <Button
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Margin="8,0,0,0"
-                            Padding="8"
-                            Background="{x:Null}"
-                            Command="{Binding UnInstallShellExtCmd}"
-                            Content="卸载右键菜单并取消关联(用户)"
-                            IsEnabled="{Binding NotSettingShellExtension}" />
-                        <StackPanel
-                            Grid.Row="1"
-                            Grid.ColumnSpan="2"
-                            Margin="0,8,0,0">
-                            <TextBlock
-                                FontSize="8pt"
-                                Foreground="#A6A6A6"
-                                Text="1. 安装右键菜单扩展后，程序会在同目录下释放菜单扩展模块 (HashCalculator[32].dll 文件)" />
-                            <TextBlock
-                                Margin="0,2,0,0"
-                                FontSize="8pt"
-                                Foreground="#A6A6A6"
-                                Text="2. 不可移动、删除、重命名 HashCalculator[32].dll 文件，否则右键菜单将失效" />
-                            <TextBlock
-                                Margin="0,2,0,0"
-                                FontSize="8pt"
-                                Foreground="#A6A6A6"
-                                Text="3. 不可重命名 HashCalculator.exe 文件，否则将无法被右键菜单唤起" />
-                            <TextBlock
-                                Margin="0,2,0,0"
-                                FontSize="8pt"
-                                Foreground="#A6A6A6"
-                                Text="4. 安装右键扩展菜单后不能移动 HashCalculator.exe，否则将无法被右键菜单唤起" />
-                            <TextBlock
-                                Margin="0,2,0,0"
-                                FontSize="8pt"
-                                Foreground="#A6A6A6"
-                                Text="5. 移动或删除 HashCalculator.exe 前先卸载右键菜单，程序会清理注册表并删除菜单扩展模块" />
-                            <TextBlock
-                                Margin="0,2,0,0"
-                                FontSize="8pt"
-                                Foreground="MediumVioletRed"
-                                Text="6. 下载新版本后先在旧版本上卸载右键菜单再打开新版本安装右键菜单以避免出现兼容问题" />
-                        </StackPanel>
-                    </Grid>
-                </GroupBox>
-            </ScrollViewer>
+                Padding="4,8,4,4"
+                Foreground="Gray"
+                Header="扩展系统右键菜单和关联 .hcb 文件">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        Padding="8"
+                        Background="{x:Null}"
+                        Command="{Binding InstallShellExtCmd}"
+                        Content="安装右键菜单并关联文件(用户)"
+                        IsEnabled="{Binding NotSettingShellExtension}" />
+                    <Button
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Padding="8"
+                        Background="{x:Null}"
+                        Command="{Binding UnInstallShellExtCmd}"
+                        Content="卸载右键菜单并取消关联(用户)"
+                        IsEnabled="{Binding NotSettingShellExtension}" />
+                    <StackPanel
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Margin="0,8,0,0">
+                        <TextBlock
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="1. 安装右键菜单后，程序会在同目录下释放菜单扩展模块 (HashCalculator[32].dll 文件)" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="2. 不可移动、删除、重命名 HashCalculator[32].dll 文件，否则右键菜单将失效" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="3. 不可重命名 HashCalculator.exe 文件，否则将无法被右键菜单唤起" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="4. 安装右键扩展菜单后不能移动 HashCalculator.exe，否则将无法被右键菜单唤起" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="5. 移动或删除 HashCalculator.exe 前先卸载右键菜单，程序会清理注册表并删除菜单扩展模块" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Foreground="MediumVioletRed"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="6. 下载新版本后先在旧版本上卸载右键菜单再打开新版本安装右键菜单以避免出现兼容问题" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="7. 关联 .hcb 文件后，通过 HashCalculator 导出的 .hcb 哈希结果文件可通过双击进行校验" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            FontSize="8pt"
+                            Style="{StaticResource DescTextBlockStyle}"
+                            Text="8. 通过双击打开 .hcb 文件进行校验的要求是待被校验的文件要与 .hcb 文件在同一文件夹下" />
+                    </StackPanel>
+                </Grid>
+            </GroupBox>
         </TabItem>
         <TabItem
             Padding="8"
             Header="默认导出类型"
             Style="{StaticResource TabItemStyle1}">
-            <ScrollViewer
+            <GroupBox
                 Margin="4"
-                HorizontalScrollBarVisibility="Auto"
-                VerticalScrollBarVisibility="Auto">
-                <GroupBox
-                    Padding="4,8,4,4"
-                    Foreground="Gray"
-                    Header="导出哈希计算结果时首选导出文件类型">
-                    <StackPanel>
-                        <Border
-                            Padding="4"
-                            BorderBrush="LightGray"
-                            BorderThickness="1">
-                            <RadioButton
-                                HorizontalContentAlignment="Stretch"
-                                VerticalContentAlignment="Center"
-                                Click="RadioButton_ExportTxt_Click"
-                                IsChecked="{Binding Source={x:Static local:Settings.Current}, Path=ResultFileTypeExportAs, Converter={StaticResource RadioExportAsTxtFileCvt}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
-                                <StackPanel>
-                                    <TextBlock Text="导出为文本文件 (.txt)" />
-                                    <TextBlock
-                                        FontSize="8pt"
-                                        Foreground="#A6A6A6"
-                                        Text="将哈希值结果导出为 .txt 后缀的文本文件，每行格式：[#算法 *哈希值 *文件名]，不包括方括号" />
-                                </StackPanel>
-                            </RadioButton>
-                        </Border>
-                        <Border
-                            Margin="0,8,0,0"
-                            Padding="4"
-                            BorderBrush="LightGray"
-                            BorderThickness="1">
-                            <RadioButton
-                                HorizontalContentAlignment="Stretch"
-                                VerticalContentAlignment="Center"
-                                Click="RadioButton_ExportHcb_Click"
-                                IsChecked="{Binding Source={x:Static local:Settings.Current}, Path=ResultFileTypeExportAs, Converter={StaticResource RadioExportAsHcbFileCvt}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
-                                <StackPanel>
-                                    <TextBlock Text="导出为文本文件 (.hcb)" />
-                                    <TextBlock
-                                        FontSize="8pt"
-                                        Foreground="#A6A6A6"
-                                        Text="内容与&lt;导出为文本文件 (.txt)&gt;相同，如果已设置文件关联则可直接双击打开 .hcb 文件进行校验" />
-                                    <TextBlock
-                                        FontSize="8pt"
-                                        Foreground="#A6A6A6"
-                                        Text="但 .hcb 文件需与待校验文件在同目录下，设置项&lt;直接使用校验依据进行校验时&gt;需选择合适策略" />
-                                </StackPanel>
-                            </RadioButton>
-                        </Border>
-                    </StackPanel>
-                </GroupBox>
-            </ScrollViewer>
+                Padding="4,8,4,4"
+                Foreground="Gray"
+                Header="导出哈希计算结果时首选导出文件类型">
+                <StackPanel>
+                    <Border
+                        Padding="4"
+                        BorderBrush="LightGray"
+                        BorderThickness="1">
+                        <RadioButton
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Center"
+                            Click="RadioButton_ExportTxt_Click"
+                            IsChecked="{Binding Source={x:Static local:Settings.Current}, Path=ResultFileTypeExportAs, Converter={StaticResource RadioExportAsTxtFileCvt}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                            <StackPanel>
+                                <TextBlock Text="导出为文本文件 (.txt)" />
+                                <TextBlock
+                                    FontSize="8pt"
+                                    Style="{StaticResource DescTextBlockStyle}"
+                                    Text="将哈希值结果导出为 .txt 后缀的文本文件，每行格式：[#算法 *哈希值 *文件名]，不包括方括号" />
+                            </StackPanel>
+                        </RadioButton>
+                    </Border>
+                    <Border
+                        Margin="0,8,0,0"
+                        Padding="4"
+                        BorderBrush="LightGray"
+                        BorderThickness="1">
+                        <RadioButton
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Center"
+                            Click="RadioButton_ExportHcb_Click"
+                            IsChecked="{Binding Source={x:Static local:Settings.Current}, Path=ResultFileTypeExportAs, Converter={StaticResource RadioExportAsHcbFileCvt}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                            <StackPanel>
+                                <TextBlock Text="导出为文本文件 (.hcb)" />
+                                <TextBlock
+                                    FontSize="8pt"
+                                    Style="{StaticResource DescTextBlockStyle}"
+                                    Text="内容与&lt;导出为文本文件 (.txt)&gt;相同，如果已设置文件关联则可直接双击打开 .hcb 文件进行校验" />
+                                <TextBlock
+                                    FontSize="8pt"
+                                    Style="{StaticResource DescTextBlockStyle}"
+                                    Text="但 .hcb 文件需与待校验文件在同目录下，设置项&lt;直接使用校验依据进行校验时&gt;需选择合适策略" />
+                            </StackPanel>
+                        </RadioButton>
+                    </Border>
+                </StackPanel>
+            </GroupBox>
         </TabItem>
     </TabControl>
 </Window>

--- a/HashCalculator/Views/SettingsPanel.xaml.cs
+++ b/HashCalculator/Views/SettingsPanel.xaml.cs
@@ -22,11 +22,6 @@ namespace HashCalculator
             e.Cancel = !this.viewModel.NotSettingShellExtension;
         }
 
-        private void Button_Confirm_Click(object sender, RoutedEventArgs e)
-        {
-            this.DialogResult = true;
-        }
-
         private void RadioButton_ExportTxt_Click(object sender, RoutedEventArgs e)
         {
             this.viewModel.ResultFileTypeExportAs = ExportType.TxtFile;


### PR DESCRIPTION
1. 设置面板的 Tab 页面里的 ScrollViewer 在窗口宽度不足的情况下，每次切换 Tab 页面时滚动滑块的初始位置有时候不是最开始而是有可能在中间，体验不好，所以删除 ScrollViewer，替代方法：部分控件文字在超出窗口宽度的情况下在末尾显示 ...；
2. 其他一些描述文字细节调整。