### PR TITLE
增加两个校验依据解析方案（通用五）和（通用六）

### DIFF
--- a/HashCalculator/ViewModels/SettingsViewModel.cs
+++ b/HashCalculator/ViewModels/SettingsViewModel.cs
@@ -1447,7 +1447,9 @@ namespace HashCalculator
                 TemplateForChecklistModel.AnyFile1.Copy(null),
                 TemplateForChecklistModel.AnyFile2.Copy(null),
                 TemplateForChecklistModel.AnyFile3.Copy(null),
-                TemplateForChecklistModel.AnyFile4.Copy(null)
+                TemplateForChecklistModel.AnyFile4.Copy(null),
+                TemplateForChecklistModel.AnyFile5.Copy(null),
+                TemplateForChecklistModel.AnyFile6.Copy(null),
             };
         }
 

--- a/HashCalculator/ViewModels/TemplateForChecklistModel.cs
+++ b/HashCalculator/ViewModels/TemplateForChecklistModel.cs
@@ -88,6 +88,22 @@ namespace HashCalculator
                 Template = "^#$algo$\\s\\*?$hash$\\s\\*?$name$\\r?$"
             };
 
+        public static readonly TemplateForChecklistModel AnyFile5 =
+            new TemplateForChecklistModel()
+            {
+                Name = "通用五",
+                Extension = null,
+                Template = "^$hash$\\|$name$\\r?$"
+            };
+
+        public static readonly TemplateForChecklistModel AnyFile6 =
+            new TemplateForChecklistModel()
+            {
+                Name = "通用六",
+                Extension = null,
+                Template = "^$hash$\\|\\d+\\|$name$\\r?$"
+            };
+
         private const string algoGroup = "algo";
         private const string hashGroup = "hash";
         private const string nameGroup = "name";


### PR DESCRIPTION
想要看到新增的解析方案，需要重置解析方案。如果有**自定义**的解析方案，请先把它们复制到其他位置保存，**重置方案后再重新添加，否则自定义方案将丢失！**

这两个方案主要用于识别油猴脚本 [115 网盘 SHA1 批量导出](https://greasyfork.org/zh-CN/scripts/400550-115-%E7%BD%91%E7%9B%98-sha1-%E6%89%B9%E9%87%8F%E5%AF%BC%E5%87%BA) 的导出格式。